### PR TITLE
[Fix] Forgotten method rename in AccessTokenValidatorService

### DIFF
--- a/resource-server/src/main/java/org/osiam/security/authorization/AccessTokenValidationService.java
+++ b/resource-server/src/main/java/org/osiam/security/authorization/AccessTokenValidationService.java
@@ -102,7 +102,7 @@ public class AccessTokenValidationService implements ResourceServerTokenServices
     public void revokeAccessTokens(String id, String token) {
         AccessToken accessToken = new AccessToken.Builder(token).build();
         OsiamConnector connector = createConnector();
-        connector.revokeAccessTokens(id, accessToken);
+        connector.revokeAllAccessTokens(id, accessToken);
     }
 
     private AccessToken validateAccessToken(String token) {


### PR DESCRIPTION
Please pull this as it unbreaks unit-tests.
