### PR TITLE
[fix] sorting by name sub-attribute breaks the result list (#251)

### DIFF
--- a/resource-server/src/main/java/org/osiam/storage/entities/UserEntity.java
+++ b/resource-server/src/main/java/org/osiam/storage/entities/UserEntity.java
@@ -26,14 +26,7 @@ package org.osiam.storage.entities;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.Lob;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Type;
@@ -48,6 +41,7 @@ import com.google.common.collect.ImmutableSet;
 public class UserEntity extends ResourceEntity {
 
     public static final String JOIN_COLUMN_NAME = "user_internal_id";
+    private static final int BATCH_SIZE = 100;
 
     @Column(nullable = false, unique = true)
     private String userName;
@@ -78,7 +72,6 @@ public class UserEntity extends ResourceEntity {
 
     private String displayName;
 
-    private static final int BATCH_SIZE = 100;
     @BatchSize(size = BATCH_SIZE)
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = JOIN_COLUMN_NAME, nullable = false)
@@ -137,7 +130,7 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * @param name
-     *            the name entity
+     *        the name entity
      */
     public void setName(NameEntity name) {
         this.name = name;
@@ -152,7 +145,7 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * @param nickName
-     *            the nick name
+     *        the nick name
      */
     public void setNickName(String nickName) {
         this.nickName = nickName;
@@ -167,7 +160,7 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * @param profileUrl
-     *            the profile url
+     *        the profile url
      */
     public void setProfileUrl(String profileUrl) {
         this.profileUrl = profileUrl;
@@ -182,7 +175,7 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * @param title
-     *            the title
+     *        the title
      */
     public void setTitle(String title) {
         this.title = title;
@@ -197,7 +190,7 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * @param userType
-     *            the user type
+     *        the user type
      */
     public void setUserType(String userType) {
         this.userType = userType;
@@ -212,7 +205,7 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * @param preferredLanguage
-     *            the preferred languages
+     *        the preferred languages
      */
     public void setPreferredLanguage(String preferredLanguage) {
         this.preferredLanguage = preferredLanguage;
@@ -227,7 +220,7 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * @param locale
-     *            the locale
+     *        the locale
      */
     public void setLocale(String locale) {
         this.locale = locale;
@@ -242,7 +235,7 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * @param timezone
-     *            the timezone
+     *        the timezone
      */
     public void setTimezone(String timezone) {
         this.timezone = timezone;
@@ -257,7 +250,7 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * @param active
-     *            the active status
+     *        the active status
      */
     public void setActive(Boolean active) {
         this.active = active;
@@ -272,7 +265,7 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * @param password
-     *            the password
+     *        the password
      */
     public void setPassword(String password) {
         this.password = password;
@@ -293,7 +286,7 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * @param userName
-     *            the user name
+     *        the user name
      */
     public void setUserName(String userName) {
         this.userName = userName;
@@ -301,7 +294,7 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * Returns an immutable view of the list of emails
-     * 
+     *
      * @return the emails entity
      */
     public Set<EmailEntity> getEmails() {
@@ -310,9 +303,9 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * Adds a new email to this user
-     * 
+     *
      * @param email
-     *            the email to add
+     *        the email to add
      */
     public void addEmail(EmailEntity email) {
         emails.add(email);
@@ -320,9 +313,9 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * Removes the given email from this user
-     * 
+     *
      * @param email
-     *            the email to remove
+     *        the email to remove
      */
     public void removeEmail(EmailEntity email) {
         emails.remove(email);
@@ -341,34 +334,34 @@ public class UserEntity extends ResourceEntity {
     public Set<ExtensionFieldValueEntity> getExtensionFieldValues() {
         return extensionFieldValues;
     }
-    
+
     /**
      * Adds a new extensionFieldValue to this user
-     * 
+     *
      * @param extensionFieldValue
-     *            the extensionFieldValue to add
+     *        the extensionFieldValue to add
      */
     public void addExtensionFieldValue(ExtensionFieldValueEntity extensionFieldValue) {
         extensionFieldValues.add(extensionFieldValue);
     }
-    
+
     /**
      * Removes the given extensionFieldValue from this user
-     * 
+     *
      * @param extensionFieldValue
-     *            the extensionFieldValue to remove
+     *        the extensionFieldValue to remove
      */
     public void removeExtensionFieldValue(ExtensionFieldValueEntity extensionFieldValue) {
         extensionFieldValues.remove(extensionFieldValue);
     }
-    
+
     /**
      * Removes all extensionFieldValues from this user
      */
     public void removeAllExtensionFieldValues(String urn) {
         ImmutableSet<ExtensionFieldValueEntity> fields = ImmutableSet.copyOf(extensionFieldValues);
         for (ExtensionFieldValueEntity extensionFieldValue : fields) {
-            if(extensionFieldValue.getExtensionField().getExtension().getUrn().equals(urn)) {
+            if (extensionFieldValue.getExtensionField().getExtension().getUrn().equals(urn)) {
                 extensionFieldValues.remove(extensionFieldValue);
             }
         }
@@ -377,24 +370,22 @@ public class UserEntity extends ResourceEntity {
     /**
      * Adds or updates an extension field value for this User. When updating, the old value of the extension field is
      * removed from this user and the new one will be added.
-     * 
+     *
      * @param extensionValue
-     *            The extension field value to add or update
+     *        The extension field value to add or update
      */
     public void addOrUpdateExtensionValue(ExtensionFieldValueEntity extensionValue) {
         if (extensionValue == null) {
             throw new IllegalArgumentException("extensionValue must not be null");
         }
-        
+
         if (extensionFieldValues.contains(extensionValue)) {
             extensionFieldValues.remove(extensionValue);
         }
-        
+
         extensionFieldValues.add(extensionValue);
     }
-    
-    
-    
+
     /**
      * @return the phone numbers entity
      */
@@ -404,9 +395,9 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * Adds a new phoneNumber to this user
-     * 
+     *
      * @param phoneNumber
-     *            the phoneNumnber to add
+     *        the phoneNumnber to add
      */
     public void addPhoneNumber(PhoneNumberEntity phoneNumber) {
         phoneNumbers.add(phoneNumber);
@@ -414,9 +405,9 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * Removes the given phoneNumber from this user
-     * 
+     *
      * @param phoneNumber
-     *            the phoneNumber to remove
+     *        the phoneNumber to remove
      */
     public void removePhoneNumber(PhoneNumberEntity phoneNumber) {
         phoneNumbers.remove(phoneNumber);
@@ -438,9 +429,9 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * Adds a new im to this user
-     * 
+     *
      * @param im
-     *            the im to add
+     *        the im to add
      */
     public void addIm(ImEntity im) {
         ims.add(im);
@@ -448,9 +439,9 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * Removes the given im from this user
-     * 
+     *
      * @param im
-     *            the im to remove
+     *        the im to remove
      */
     public void removeIm(ImEntity im) {
         ims.remove(im);
@@ -472,9 +463,9 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * Adds a new photo to this user
-     * 
+     *
      * @param photo
-     *            the photo to add
+     *        the photo to add
      */
     public void addPhoto(PhotoEntity photo) {
         photos.add(photo);
@@ -482,9 +473,9 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * Removes the given photo from this user
-     * 
+     *
      * @param photo
-     *            the photo to remove
+     *        the photo to remove
      */
     public void removePhoto(PhotoEntity photo) {
         photos.remove(photo);
@@ -506,9 +497,9 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * Adds a new address to this user
-     * 
+     *
      * @param address
-     *            the address to add
+     *        the address to add
      */
     public void addAddress(AddressEntity address) {
         addresses.add(address);
@@ -516,9 +507,9 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * Removes the given address from this user
-     * 
+     *
      * @param address
-     *            the address to remove
+     *        the address to remove
      */
     public void removeAddress(AddressEntity address) {
         addresses.remove(address);
@@ -540,9 +531,9 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * Adds a new entitlement to this user
-     * 
+     *
      * @param entitlement
-     *            the entitlement to add
+     *        the entitlement to add
      */
     public void addEntitlement(EntitlementEntity entitlement) {
         entitlements.add(entitlement);
@@ -550,9 +541,9 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * Removes the given entitlement from this user
-     * 
+     *
      * @param entitlement
-     *            the entitlement to remove
+     *        the entitlement to remove
      */
     public void removeEntitlement(EntitlementEntity entitlement) {
         entitlements.remove(entitlement);
@@ -574,9 +565,9 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * Adds a new role to this user
-     * 
+     *
      * @param role
-     *            the role to add
+     *        the role to add
      */
     public void addRole(RoleEntity role) {
         roles.add(role);
@@ -584,9 +575,9 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * Removes the given role from this user
-     * 
+     *
      * @param role
-     *            the role to remove
+     *        the role to remove
      */
     public void removeRole(RoleEntity role) {
         roles.remove(role);
@@ -608,9 +599,9 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * Adds a new x509Certificate to this user
-     * 
+     *
      * @param x509Certificate
-     *            the x509Certificate to add
+     *        the x509Certificate to add
      */
     public void addX509Certificate(X509CertificateEntity x509Certificate) {
         x509Certificates.add(x509Certificate);
@@ -618,9 +609,9 @@ public class UserEntity extends ResourceEntity {
 
     /**
      * Removes the given x509Certificate from this user
-     * 
+     *
      * @param x509Certificate
-     *            the x509Certificate to remove
+     *        the x509Certificate to remove
      */
     public void removeX509Certificate(X509CertificateEntity x509Certificate) {
         x509Certificates.remove(x509Certificate);

--- a/resource-server/src/main/java/org/osiam/storage/query/OsiamAntlrErrorListener.java
+++ b/resource-server/src/main/java/org/osiam/storage/query/OsiamAntlrErrorListener.java
@@ -65,7 +65,7 @@ public class OsiamAntlrErrorListener implements ANTLRErrorListener {
      */
     @Override
     public void reportAmbiguity(@NotNull Parser recognizer, @NotNull DFA dfa, int startIndex, int stopIndex,
-            boolean exact, @NotNull BitSet ambigAlts, @NotNull ATNConfigSet configs) {
+            boolean exact, @Nullable BitSet ambigAlts, @NotNull ATNConfigSet configs) {
     }
 
     /**

--- a/resource-server/src/main/java/org/osiam/storage/query/UserQueryField.java
+++ b/resource-server/src/main/java/org/osiam/storage/query/UserQueryField.java
@@ -27,47 +27,14 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Expression;
-import javax.persistence.criteria.JoinType;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
-import javax.persistence.criteria.SetJoin;
+import javax.persistence.criteria.*;
 
 import org.joda.time.format.ISODateTimeFormat;
-import org.osiam.resources.scim.Address;
-import org.osiam.resources.scim.Email;
-import org.osiam.resources.scim.Entitlement;
-import org.osiam.resources.scim.Im;
-import org.osiam.resources.scim.PhoneNumber;
-import org.osiam.resources.scim.Photo;
-import org.osiam.storage.entities.AddressEntity;
-import org.osiam.storage.entities.AddressEntity_;
-import org.osiam.storage.entities.BaseMultiValuedAttributeEntityWithValue_;
-import org.osiam.storage.entities.BaseMultiValuedAttributeEntity_;
-import org.osiam.storage.entities.EmailEntity;
-import org.osiam.storage.entities.EmailEntity_;
-import org.osiam.storage.entities.EntitlementEntity;
-import org.osiam.storage.entities.EntitlementEntity_;
-import org.osiam.storage.entities.GroupEntity;
-import org.osiam.storage.entities.GroupEntity_;
-import org.osiam.storage.entities.ImEntity;
-import org.osiam.storage.entities.ImEntity_;
-import org.osiam.storage.entities.MetaEntity_;
-import org.osiam.storage.entities.NameEntity_;
-import org.osiam.storage.entities.PhoneNumberEntity;
-import org.osiam.storage.entities.PhoneNumberEntity_;
-import org.osiam.storage.entities.PhotoEntity;
-import org.osiam.storage.entities.PhotoEntity_;
-import org.osiam.storage.entities.ResourceEntity_;
-import org.osiam.storage.entities.RoleEntity;
-import org.osiam.storage.entities.RoleEntity_;
-import org.osiam.storage.entities.UserEntity;
-import org.osiam.storage.entities.UserEntity_;
-import org.osiam.storage.entities.X509CertificateEntity;
+import org.osiam.resources.scim.*;
+import org.osiam.storage.entities.*;
 
 public enum UserQueryField implements QueryField<UserEntity> {
-    
+
     EXTERNALID("externalid") {
         @Override
         public Predicate addFilter(Root<UserEntity> root,
@@ -263,7 +230,7 @@ public enum UserQueryField implements QueryField<UserEntity> {
 
         @Override
         public Expression<?> createSortByField(Root<UserEntity> root, CriteriaBuilder cb) {
-            return root.get(UserEntity_.name).get(NameEntity_.formatted);
+            return createOrGetJoinForName(root).get(NameEntity_.formatted);
         }
 
     },
@@ -277,7 +244,7 @@ public enum UserQueryField implements QueryField<UserEntity> {
 
         @Override
         public Expression<?> createSortByField(Root<UserEntity> root, CriteriaBuilder cb) {
-            return root.get(UserEntity_.name).get(NameEntity_.familyName);
+            return createOrGetJoinForName(root).get(NameEntity_.familyName);
         }
 
     },
@@ -291,9 +258,8 @@ public enum UserQueryField implements QueryField<UserEntity> {
 
         @Override
         public Expression<?> createSortByField(Root<UserEntity> root, CriteriaBuilder cb) {
-            return root.get(UserEntity_.name).get(NameEntity_.givenName);
+            return createOrGetJoinForName(root).get(NameEntity_.givenName);
         }
-
     },
     NAME_MIDDLENAME("name.middlename") {
         @Override
@@ -305,7 +271,7 @@ public enum UserQueryField implements QueryField<UserEntity> {
 
         @Override
         public Expression<?> createSortByField(Root<UserEntity> root, CriteriaBuilder cb) {
-            return root.get(UserEntity_.name).get(NameEntity_.middleName);
+            return createOrGetJoinForName(root).get(NameEntity_.middleName);
         }
 
     },
@@ -319,7 +285,7 @@ public enum UserQueryField implements QueryField<UserEntity> {
 
         @Override
         public Expression<?> createSortByField(Root<UserEntity> root, CriteriaBuilder cb) {
-            return root.get(UserEntity_.name).get(NameEntity_.honorificPrefix);
+            return createOrGetJoinForName(root).get(NameEntity_.honorificPrefix);
         }
 
     },
@@ -333,7 +299,7 @@ public enum UserQueryField implements QueryField<UserEntity> {
 
         @Override
         public Expression<?> createSortByField(Root<UserEntity> root, CriteriaBuilder cb) {
-            return root.get(UserEntity_.name).get(NameEntity_.honorificSuffix);
+            return createOrGetJoinForName(root).get(NameEntity_.honorificSuffix);
         }
 
     },
@@ -867,6 +833,8 @@ public enum UserQueryField implements QueryField<UserEntity> {
 
     private static final Map<String, UserQueryField> STRING_TO_ENUM = new HashMap<>();
 
+    private static final String JOIN_ALIAS_FOR_NAME = "nameJoin";
+
     static {
         for (UserQueryField filterField : values()) {
             STRING_TO_ENUM.put(filterField.toString(), filterField);
@@ -882,6 +850,21 @@ public enum UserQueryField implements QueryField<UserEntity> {
     protected RuntimeException handleSortByFieldNotSupported(String fieldName) {
         throw new RuntimeException("Sorting by " + fieldName + " is not supported yet"); // NOSONAR - will be removed
                                                                                          // after implementing
+    }
+
+    @SuppressWarnings("unchecked")
+    protected Join<UserEntity, NameEntity> createOrGetJoinForName(final Root<UserEntity> root) {
+
+        for (final Join<UserEntity, ?> currentJoin : root.getJoins()) {
+            if (currentJoin.getAlias() != null && currentJoin.getAlias().equals(JOIN_ALIAS_FOR_NAME)) {
+                return (Join<UserEntity, NameEntity>) currentJoin;
+            }
+        }
+
+        Join<UserEntity, NameEntity> join = root.join(UserEntity_.name, JoinType.LEFT);
+        join.alias(JOIN_ALIAS_FOR_NAME);
+
+        return join;
     }
 
     @Override


### PR DESCRIPTION
This was caused by Hibernate adding an implicit join for the `scim_name` table when sorting by a `Name` sub-attribute. Unfortunately, Hibernate makes this a `CROSS JOIN` with a `WHERE` clause for filtering non-matching rows. Fixed this by explicitly adding a `LEFT JOIN` if and only if the client request an ordering by a `Name` sub-attribute.
