### PR TITLE
Remove database jars from wars

### DIFF
--- a/auth-server/pom.xml
+++ b/auth-server/pom.xml
@@ -284,11 +284,13 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/resource-server/pom.xml
+++ b/resource-server/pom.xml
@@ -298,11 +298,13 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This pull-request contains the changes in the pom.
Now the jars for the database-interfaces won't be put in the war.

Here is the git gist, where is shown, how to find the jars and where you have to place them.
https://gist.github.com/stweiz/c9863994b0260096ec81