### PR TITLE
[release] bumped connector4java version to snapshot after released

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
             <dependency>
                 <groupId>org.osiam</groupId>
                 <artifactId>connector4java</artifactId>
-                <version>1.3.1</version>
+                <version>1.4-SNAPSHOT</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This pull request change the release-version to snapshot
