### PR TITLE
Remove unneccessary mock of Date in test

### DIFF
--- a/resource-server/src/test/groovy/org/osiam/storage/entities/MetaEntitySpec.groovy
+++ b/resource-server/src/test/groovy/org/osiam/storage/entities/MetaEntitySpec.groovy
@@ -28,7 +28,6 @@ import spock.lang.Specification
 class MetaEntitySpec extends Specification {
 
     MetaEntity metaEntity = new MetaEntity()
-    def date = Mock(Date)
 
     def "should not throw NullpointerException if created is null"() {
         when:


### PR DESCRIPTION
This pull request removes an unneccessary (and unused) mock of the Date class in MetaEntitySpec.groovy. The project does now build again on Java 8  